### PR TITLE
fix: cannot add MUI components caused by cache provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "restcipe-v2.0",
       "version": "0.1.0",
       "dependencies": {
+        "@emotion/cache": "^11.11.0",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@hookform/resolvers": "^3.3.2",
-        "@mui/material": "^5.14.20",
+        "@mui/material": "^5.15.0",
+        "@mui/material-nextjs": "^5.15.0",
         "next": "14.0.4",
         "react": "^18",
         "react-dom": "^18",
@@ -505,14 +507,14 @@
       "dev": true
     },
     "node_modules/@mui/base": {
-      "version": "5.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.26.tgz",
-      "integrity": "sha512-gPMRKC84VRw+tjqYoyBzyrBUqHQucMXdlBpYazHa5rCXrb91fYEQk5SqQ2U5kjxx9QxZxTBvWAmZ6DblIgaGhQ==",
+      "version": "5.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.27.tgz",
+      "integrity": "sha512-duL37qxihT1N0pW/gyXVezP7SttLkF+cLAs/y6g6ubEFmVadjbnZ45SeF12/vAiKzqwf5M0uFH1cczIPXFZygA==",
       "dependencies": {
-        "@babel/runtime": "^7.23.4",
+        "@babel/runtime": "^7.23.5",
         "@floating-ui/react-dom": "^2.0.4",
-        "@mui/types": "^7.2.10",
-        "@mui/utils": "^5.14.20",
+        "@mui/types": "^7.2.11",
+        "@mui/utils": "^5.15.0",
         "@popperjs/core": "^2.11.8",
         "clsx": "^2.0.0",
         "prop-types": "^15.8.1"
@@ -536,25 +538,25 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.14.20",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.20.tgz",
-      "integrity": "sha512-fXoGe8VOrIYajqALysFuyal1q1YmBARqJ3tmnWYDVl0scu8f6h6tZQbS2K8BY28QwkWNGyv4WRfuUkzN5HR3Ow==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.0.tgz",
+      "integrity": "sha512-NpGtlHwuyLfJtdrlERXb8qRqd279O0VnuGaZAor1ehdNhUJOD1bSxHDeXKZkbqNpvi50hasFj7lsbTpluworTQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       }
     },
     "node_modules/@mui/material": {
-      "version": "5.14.20",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.14.20.tgz",
-      "integrity": "sha512-SUcPZnN6e0h1AtrDktEl76Dsyo/7pyEUQ+SAVe9XhHg/iliA0b4Vo+Eg4HbNkELsMbpDsUF4WHp7rgflPG7qYQ==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.15.0.tgz",
+      "integrity": "sha512-60CDI/hQNwJv9a3vEZtFG7zz0USdQhVwpBd3fZqrzhuXSdiMdYMaZcCXeX/KMuNq0ZxQEAZd74Pv+gOb408QVA==",
       "dependencies": {
-        "@babel/runtime": "^7.23.4",
-        "@mui/base": "5.0.0-beta.26",
-        "@mui/core-downloads-tracker": "^5.14.20",
-        "@mui/system": "^5.14.20",
-        "@mui/types": "^7.2.10",
-        "@mui/utils": "^5.14.20",
+        "@babel/runtime": "^7.23.5",
+        "@mui/base": "5.0.0-beta.27",
+        "@mui/core-downloads-tracker": "^5.15.0",
+        "@mui/system": "^5.15.0",
+        "@mui/types": "^7.2.11",
+        "@mui/utils": "^5.15.0",
         "@types/react-transition-group": "^4.4.9",
         "clsx": "^2.0.0",
         "csstype": "^3.1.2",
@@ -588,18 +590,49 @@
         }
       }
     },
+    "node_modules/@mui/material-nextjs": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@mui/material-nextjs/-/material-nextjs-5.15.0.tgz",
+      "integrity": "sha512-UC3lnoRqJXoWUBeekqjxC4CpxMElz4D4bBCegOhrm80qGV1cP5TBJGjalqoSUq6HSl+COVv6u//AjjIMKCj/qA==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/cache": "^11.11.0",
+        "@emotion/server": "^11.11.0",
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "next": "^13.0.0 || ^14.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/cache": {
+          "optional": true
+        },
+        "@emotion/server": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@mui/material/node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.14.20",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.20.tgz",
-      "integrity": "sha512-WV560e1vhs2IHCh0pgUaWHznrcrVoW9+cDCahU1VTkuwPokWVvb71ccWQ1f8Y3tRBPPcNkU2dChkkRJChLmQlQ==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.15.0.tgz",
+      "integrity": "sha512-7WxtIhXxNek0JjtsYy+ut2LtFSLpsUW5JSDehQO+jF7itJ8ehy7Bd9bSt2yIllbwGjCFowLfYpPk2Ykgvqm1tA==",
       "dependencies": {
-        "@babel/runtime": "^7.23.4",
-        "@mui/utils": "^5.14.20",
+        "@babel/runtime": "^7.23.5",
+        "@mui/utils": "^5.15.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -620,11 +653,11 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.14.20",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.14.20.tgz",
-      "integrity": "sha512-Vs4nGptd9wRslo9zeRkuWcZeIEp+oYbODy+fiZKqqr4CH1Gfi9fdP0Q1tGYk8OiJ2EPB/tZSAyOy62Hyp/iP7g==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.15.0.tgz",
+      "integrity": "sha512-6NysIsHkuUS2lF+Lzv1jiK3UjBJk854/vKVcJQVGKlPiqNEVZJNlwaSpsaU5xYXxWEZYfbVFSAomLOS/LV/ovQ==",
       "dependencies": {
-        "@babel/runtime": "^7.23.4",
+        "@babel/runtime": "^7.23.5",
         "@emotion/cache": "^11.11.0",
         "csstype": "^3.1.2",
         "prop-types": "^15.8.1"
@@ -651,15 +684,15 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.14.20",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.20.tgz",
-      "integrity": "sha512-jKOGtK4VfYZG5kdaryUHss4X6hzcfh0AihT8gmnkfqRtWP7xjY+vPaUhhuSeibE5sqA5wCtdY75z6ep9pxFnIg==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.15.0.tgz",
+      "integrity": "sha512-8TPjfTlYBNB7/zBJRL4QOD9kImwdZObbiYNh0+hxvhXr2koezGx8USwPXj8y/JynbzGCkIybkUztCdWlMZe6OQ==",
       "dependencies": {
-        "@babel/runtime": "^7.23.4",
-        "@mui/private-theming": "^5.14.20",
-        "@mui/styled-engine": "^5.14.19",
-        "@mui/types": "^7.2.10",
-        "@mui/utils": "^5.14.20",
+        "@babel/runtime": "^7.23.5",
+        "@mui/private-theming": "^5.15.0",
+        "@mui/styled-engine": "^5.15.0",
+        "@mui/types": "^7.2.11",
+        "@mui/utils": "^5.15.0",
         "clsx": "^2.0.0",
         "csstype": "^3.1.2",
         "prop-types": "^15.8.1"
@@ -690,9 +723,9 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.10",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.10.tgz",
-      "integrity": "sha512-wX1vbDC+lzF7FlhT6A3ffRZgEoKWPF8VqRoTu4lZwouFX2t90KyCMsgepMw5DxLak1BSp/KP86CmtZttikb/gQ==",
+      "version": "7.2.11",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.11.tgz",
+      "integrity": "sha512-KWe/QTEsFFlFSH+qRYf3zoFEj3z67s+qAuSnMMg+gFwbxG7P96Hm6g300inQL1Wy///gSRb8juX7Wafvp93m3w==",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0"
       },
@@ -703,11 +736,11 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.14.20",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.20.tgz",
-      "integrity": "sha512-Y6yL5MoFmtQml20DZnaaK1znrCEwG6/vRSzW8PKOTrzhyqKIql0FazZRUR7sA5EPASgiyKZfq0FPwISRXm5NdA==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.15.0.tgz",
+      "integrity": "sha512-XSmTKStpKYamewxyJ256+srwEnsT3/6eNo6G7+WC1tj2Iq9GfUJ/6yUoB7YXjOD2jTZ3XobToZm4pVz1LBt6GA==",
       "dependencies": {
-        "@babel/runtime": "^7.23.4",
+        "@babel/runtime": "^7.23.5",
         "@types/prop-types": "^15.7.11",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@emotion/cache": "^11.11.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@hookform/resolvers": "^3.3.2",
-    "@mui/material": "^5.14.20",
+    "@mui/material": "^5.15.0",
+    "@mui/material-nextjs": "^5.15.0",
     "next": "14.0.4",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,7 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import "./globals.css";
 import ThemeRegistry from "@/components/ThemeRegistry";
 import Header from "@/components/Page/Header";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
 	title: "Restcipe",
@@ -19,7 +16,7 @@ export default function RootLayout({
 	return (
 		<html lang="en">
 			<body>
-				<ThemeRegistry options={{ key: "mui" }}>
+				<ThemeRegistry>
 					<Header />
 					{children}
 				</ThemeRegistry>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import styles from "./page.module.css";
-import { Box, Button, Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import Form from "@/components/Form/Form";
 
 export default function Home() {
@@ -12,6 +12,19 @@ export default function Home() {
 		<Box sx={{ height: "100vh", width: "100vw", bgcolor: "white" }}>
 			<Typography variant="h1">Restcipe</Typography>
 			<Form />
+			<Box
+				sx={{
+					height: "100vh",
+					width: "100vw",
+					bgcolor: "primary.main",
+				}}
+			>
+				hello
+			</Box>
+			<Box sx={{ height: "100vh", width: "100vw", bgcolor: "red" }}></Box>
+			<Box
+				sx={{ height: "100vh", width: "100vw", bgcolor: "blue" }}
+			></Box>
 		</Box>
 	);
 }

--- a/src/components/Form/FormTextField.tsx
+++ b/src/components/Form/FormTextField.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { TextField, TextFieldProps } from "@mui/material";
 import React from "react";
 import { Controller, Control } from "react-hook-form";

--- a/src/components/Page/Header.tsx
+++ b/src/components/Page/Header.tsx
@@ -1,7 +1,9 @@
+// "use client";
+import { Box } from "@mui/material";
 import React from "react";
 
 const Header = () => {
-	return <div>Header</div>;
+	return <Box>Header</Box>;
 };
 
 export default Header;

--- a/src/components/ThemeRegistry.tsx
+++ b/src/components/ThemeRegistry.tsx
@@ -1,69 +1,25 @@
 "use client";
-import createCache, { Options } from "@emotion/cache";
-import { useServerInsertedHTML } from "next/navigation";
-import { CacheProvider } from "@emotion/react";
 import { ThemeProvider } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
 import theme from "@/theme/theme";
-import { ReactNode, useState } from "react";
+import { ReactNode } from "react";
+import { AppRouterCacheProvider } from "@mui/material-nextjs/v14-appRouter";
 
 // This implementation is from emotion-js
 // https://github.com/emotion-js/emotion/issues/2928#issuecomment-1319747902
 
 interface Props {
-	options: Options;
 	children: ReactNode;
 }
 
 export default function ThemeRegistry(props: Props) {
-	const { options, children } = props;
-
-	const [{ cache, flush }] = useState(() => {
-		const cache = createCache(options);
-		cache.compat = true;
-		const prevInsert = cache.insert;
-		let inserted: string[] = [];
-		cache.insert = (...args) => {
-			const serialized = args[1];
-			if (cache.inserted[serialized.name] === undefined) {
-				inserted.push(serialized.name);
-			}
-			return prevInsert(...args);
-		};
-		const flush = () => {
-			const prevInserted = inserted;
-			inserted = [];
-			return prevInserted;
-		};
-		return { cache, flush };
-	});
-
-	useServerInsertedHTML(() => {
-		const names = flush();
-		if (names.length === 0) {
-			return null;
-		}
-		let styles = "";
-		for (const name of names) {
-			styles += cache.inserted[name];
-		}
-		return (
-			<style
-				key={cache.key}
-				data-emotion={`${cache.key} ${names.join(" ")}`}
-				dangerouslySetInnerHTML={{
-					__html: styles,
-				}}
-			/>
-		);
-	});
-
+	const { children } = props;
 	return (
-		<CacheProvider value={cache}>
+		<AppRouterCacheProvider>
 			<ThemeProvider theme={theme}>
 				<CssBaseline />
 				{children}
 			</ThemeProvider>
-		</CacheProvider>
+		</AppRouterCacheProvider>
 	);
 }


### PR DESCRIPTION
MUI components need to be put inside CacheProvider components in order to be loaded when they syncs to the server components. I follow MUI's docs to fix the problem: https://mui.com/material-ui/guides/nextjs/ 